### PR TITLE
Remove unused sbt-scalajs-bundler plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.21.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("io.github.nafg.mergify" % "sbt-mergify-github-actions" % "0.9.1")
 libraryDependencies += "io.github.nafg.scalac-options" %% "scalac-options" % "0.6.0"


### PR DESCRIPTION
## Summary

- remove the unused `sbt-scalajs-bundler` meta-build plugin
- keep the actively used `sbt-scalajs` plugin unchanged
- unblock evaluation of the sbt 2 update, for which no `sbt-scalajs-bundler_sbt2_3` artifact exists

The repository has no bundler, webpack, `npmDependencies`, or related plugin settings; its `npm view` calls are direct shell commands.

## Validation

- `sbt test`
- `git diff --check`