### PR TITLE
Use major-only Scala selectors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.x, 3.3.x]
+        scala: [2.x, 3.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -86,22 +86,22 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.13.x)
+      - name: Download target directories (2.x)
         uses: actions/download-artifact@v8
         with:
-          name: target-${{ matrix.os }}-2.13.x-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.x)
+      - name: Inflate target directories (2.x)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.3.x)
+      - name: Download target directories (3.x)
         uses: actions/download-artifact@v8
         with:
-          name: target-${{ matrix.os }}-3.3.x-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.x-${{ matrix.java }}
 
-      - name: Inflate target directories (3.3.x)
+      - name: Inflate target directories (3.x)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,8 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@17)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 2.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 3.x, temurin@17)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -7,7 +7,7 @@ inThisBuild(List(
   dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
   dynverSonatypeSnapshots := true,
   githubWorkflowEnv += ("SBT_OPTS" -> "-Xmx2g"),
-  githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
+  githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\.\\d+\\.\\d+$", ".x")),
   githubWorkflowTargetTags ++= Seq("v*"),
   githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
   githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),


### PR DESCRIPTION
## Summary

- generate `2.x` and `3.x` CI selectors instead of minor-specific `2.13.x` and `3.3.x` selectors
- regenerate the GitHub Actions workflow, including artifact names
- regenerate Mergify conditions for the new check names

This prevents Scala Steward minor-version updates such as Scala 3.3 → 3.8 from leaving the build matrix pointed at a version that is no longer present in `crossScalaVersions`.

## Validation

- `sbt githubWorkflowGenerate`
- `sbt '++ 2.x; githubWorkflowCheck; test'`\n- `sbt '++ 3.x; test'`\n- `git diff --check`