### PR TITLE
Add Tabler CSS DSL modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ write code like this:
  * Bootstrap 3
  * Bootstrap 4
  * Bulma
+ * Tabler
  * Semantic UI
  * Fomantic UI
  * Font Awesome

--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,14 @@ val bulmaConfig =
     "https://cdn.jsdelivr.net/npm/bulma@" + _ + "/css/bulma.min.css"
   )
 
+val tablerConfig =
+  CssDslConfig(
+    "Tabler",
+    Set(None, Some("t")),
+    latestTag("@tabler/core"),
+    "https://cdn.jsdelivr.net/npm/@tabler/core@" + _ + "/dist/css/tabler.min.css"
+  )
+
 val semanticUiConfig =
   CssDslConfig(
     "Semantic UI",
@@ -123,6 +131,11 @@ lazy val bulma_scalajsreact =
   project.enablePlugins(ScalaJSPlugin, GeneratorPlugin).settings(scalaJsReactSettings(bulmaConfig))
 lazy val bulma_scalatags =
   project.enablePlugins(GeneratorPlugin).settings(scalatagsSettings(bulmaConfig))
+
+lazy val tabler_scalajsreact =
+  project.enablePlugins(ScalaJSPlugin, GeneratorPlugin).settings(scalaJsReactSettings(tablerConfig))
+lazy val tabler_scalatags =
+  project.enablePlugins(GeneratorPlugin).settings(scalatagsSettings(tablerConfig))
 
 lazy val semanticui_scalajsreact =
   project.enablePlugins(ScalaJSPlugin, GeneratorPlugin).settings(scalaJsReactSettings(semanticUiConfig))

--- a/project/CssExtractor.scala
+++ b/project/CssExtractor.scala
@@ -1,4 +1,5 @@
 import java.net.URL
+import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters.*
 import scala.collection.immutable.SortedSet
@@ -73,8 +74,9 @@ object CssExtractor {
     getClassesFromRules(sheet.getAllRules)
 
   def getClassesFromURL(url: URL): SortedSet[String] = {
-    val reader: IHasReader = () => new java.io.InputStreamReader(url.openStream())
-    val sheet = CSSReader.readFromReader(reader, new CSSReaderSettings())
+    val reader: IHasReader = () => new java.io.InputStreamReader(url.openStream(), StandardCharsets.UTF_8)
+    val settings = new CSSReaderSettings().setBrowserCompliantMode(true)
+    val sheet = CSSReader.readFromReader(reader, settings)
     SortedSet(getClassesFromSheet(sheet).toSeq *)
   }
 }

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -12,10 +12,25 @@ class Generator(packageName: String,
     s2.take(1).toLowerCase + s2.drop(1)
   }
 
-  private def ident(cls: String) = {
-    val camelized = camelize(cls)
-    prefix.fold(camelized)(_ + camelized.capitalize)
+  private lazy val identifiers = {
+    val classesByIdentifier = classes.groupBy(camelize)
+    val result = classes.iterator.map { cls =>
+      val camelized = camelize(cls)
+      val identifier =
+        if (classesByIdentifier(camelized).size > 1 && cls != camelized)
+          prefix.fold(cls)(_ + "-" + cls)
+        else
+          prefix.fold(camelized)(_ + camelized.capitalize)
+      cls -> identifier
+    }.toMap
+    val duplicates = result.values.groupBy(identity).collect {
+      case (identifier, values) if values.size > 1 => identifier
+    }
+    require(duplicates.isEmpty, s"Generated duplicate identifiers: ${duplicates.mkString(", ")}")
+    result
   }
+
+  private def ident(cls: String) = identifiers(cls)
 
   def defs: List[Stat] =
     classes.toList.map { cls =>


### PR DESCRIPTION
## Summary

- add ScalaTags and scalajs-react modules generated from `@tabler/core`
- provide unprefixed `Dsl` and `t`-prefixed `TDsl` flavors
- enable browser-compliant CSS parsing for Tabler attribute selectors
- disambiguate classes that camelize to the same Scala identifier (for example, `h-1` and `h1`)
- document Tabler as a supported CSS library

## Validation

- `sbt '++2.13.18; test' '++3.8.4; test' githubWorkflowCheck`\n- compared generated Scala for all existing modules against an `origin/master` baseline; no differences\n- `git diff --check`