### PR TITLE
Regenerate README after publishing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
     tags: [v*]
 
 permissions:
-  actions: write
   contents: read
 
 env:
@@ -73,6 +72,9 @@ jobs:
         scala: [3.8.4]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v7
@@ -118,6 +120,4 @@ jobs:
         run: sbt ci-release
 
       - name: Regenerate README for the release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run regenerate-readme.yml --ref master --field release-ref="${GITHUB_REF_NAME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
     branches: ['**']
     tags: [v*]
 
+permissions:
+  actions: write
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SBT_OPTS: '-Xmx2g'
@@ -112,3 +116,8 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         run: sbt ci-release
+
+      - name: Regenerate README for the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run regenerate-readme.yml --ref master --field release-ref="${GITHUB_REF_NAME}"

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ inputs.release-ref }}
 
       - name: Setup Java
@@ -34,7 +35,18 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Regenerate README
-        run: sbt generateInstallInstructions
+        run: |
+          sbt generateInstallInstructions
+          cp README.md "$RUNNER_TEMP/README.md"
+
+      - name: Checkout the target branch
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: master
+
+      - name: Restore the regenerated README
+        run: cp "$RUNNER_TEMP/README.md" README.md
 
       - name: Open README update pull request
         uses: peter-evans/create-pull-request@v8
@@ -49,6 +61,7 @@ jobs:
             Update the generated installation instructions to use the versions
             published from ${{ inputs.release-ref }}.
           title: Regenerate README for ${{ inputs.release-ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             Regenerates the installation instructions in `README.md` after publishing
             `${{ inputs.release-ref }}`.

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -1,0 +1,57 @@
+name: Regenerate README
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-ref:
+        description: Git tag or ref whose published versions should appear in the README
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regenerate:
+    name: Regenerate README
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the release
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release-ref }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Regenerate README
+        run: sbt generateInstallInstructions
+
+      - name: Open README update pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: README.md
+          base: master
+          branch: automation/regenerate-readme
+          delete-branch: true
+          commit-message: |
+            Regenerate README for ${{ inputs.release-ref }}
+
+            Update the generated installation instructions to use the versions
+            published from ${{ inputs.release-ref }}.
+          title: Regenerate README for ${{ inputs.release-ref }}
+          body: |
+            Regenerates the installation instructions in `README.md` after publishing
+            `${{ inputs.release-ref }}`.
+
+            This pull request was created automatically by the
+            [Regenerate README workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/ci.sbt
+++ b/ci.sbt
@@ -8,9 +8,16 @@ inThisBuild(List(
   dynverSonatypeSnapshots := true,
   githubWorkflowEnv += ("SBT_OPTS" -> "-Xmx2g"),
   githubWorkflowPermissions := Some(Permissions.Specify(Map(
-    PermissionScope.Actions -> PermissionValue.Write,
     PermissionScope.Contents -> PermissionValue.Read
   ))),
+  githubWorkflowGeneratedCI ~= (_.map {
+    case job if job.id == "publish" =>
+      job.copy(permissions = Some(Permissions.Specify(Map(
+        PermissionScope.Actions -> PermissionValue.Write,
+        PermissionScope.Contents -> PermissionValue.Read
+      ))))
+    case job => job
+  }),
   githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\.\\d+\\.\\d+$", ".x")),
   githubWorkflowGeneratedUploadSteps := Seq(
     WorkflowStep.Run(
@@ -38,11 +45,12 @@ inThisBuild(List(
         "SONATYPE_PASSWORD" -> "${{ secrets.SONATYPE_PASSWORD }}",
         "SONATYPE_USERNAME" -> "${{ secrets.SONATYPE_USERNAME }}"
       )
-    ),
+    )
+  ),
+  githubWorkflowPublishPostamble := Seq(
     WorkflowStep.Run(
       List("gh workflow run regenerate-readme.yml --ref master --field release-ref=\"${GITHUB_REF_NAME}\""),
-      name = Some("Regenerate README for the release"),
-      env = Map("GH_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}")
+      name = Some("Regenerate README for the release")
     )
   )
 ))

--- a/ci.sbt
+++ b/ci.sbt
@@ -7,6 +7,10 @@ inThisBuild(List(
   dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
   dynverSonatypeSnapshots := true,
   githubWorkflowEnv += ("SBT_OPTS" -> "-Xmx2g"),
+  githubWorkflowPermissions := Some(Permissions.Specify(Map(
+    PermissionScope.Actions -> PermissionValue.Write,
+    PermissionScope.Contents -> PermissionValue.Read
+  ))),
   githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\.\\d+\\.\\d+$", ".x")),
   githubWorkflowGeneratedUploadSteps := Seq(
     WorkflowStep.Run(
@@ -34,6 +38,11 @@ inThisBuild(List(
         "SONATYPE_PASSWORD" -> "${{ secrets.SONATYPE_PASSWORD }}",
         "SONATYPE_USERNAME" -> "${{ secrets.SONATYPE_USERNAME }}"
       )
+    ),
+    WorkflowStep.Run(
+      List("gh workflow run regenerate-readme.yml --ref master --field release-ref=\"${GITHUB_REF_NAME}\""),
+      name = Some("Regenerate README for the release"),
+      env = Map("GH_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}")
     )
   )
 ))


### PR DESCRIPTION
## Summary

- add a manually dispatchable workflow that regenerates `README.md` from a release tag or ref
- open or update a narrowly scoped README pull request with the generated installation instructions
- dispatch the same workflow after `ci-release` succeeds
- narrow the generated CI workflow token to `actions: write` and `contents: read`

## Why this approach

A dedicated workflow keeps README maintenance separate from artifact publication while giving us one entry point that can be run manually for testing or recovery. The publish job dispatches it only after `ci-release` succeeds, so failed releases do not produce documentation updates.

The workflow opens a PR rather than pushing directly to `master`, preserving review and branch-protection behavior. It accepts an explicit release ref so it can be tested against an existing tag without publishing again.

## Alternatives considered

### Generate and open the PR directly in the publish job

**Pros:** fewer workflow hops; a failure is reported directly on the release run.

**Cons:** not independently runnable; testing the complete path requires a release; publication and documentation permissions remain coupled.

### Commit the generated README directly to `master`

**Pros:** simplest and immediately updates the documentation.

**Cons:** bypasses review, may conflict with branch protection, and is more vulnerable to concurrent changes on `master`.

### Trigger from a GitHub `release.published` event

**Pros:** clean semantic separation from artifact publication.

**Cons:** this project publishes from tags through `sbt ci-release`; a GitHub Release event is not guaranteed to exist, so successful artifact publication could leave the README stale.

### Trigger through `workflow_run`

**Pros:** decouples the follow-up from the publishing steps.

**Cons:** filtering tag runs reliably is more indirect, and manual reuse still requires additional workflow plumbing.

## Validation

- `sbt githubWorkflowGenerate`
- `sbt githubWorkflowCheck`
- parsed both workflow files as YAML
- ran `sbt generateInstallInstructions` from a normal clone checked out at `v0.10.0`; it updated the generated artifact versions from `0.9.0` to `0.10.0`
- verified repository Actions settings allow Actions-created pull requests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - README installation instructions are now regenerated automatically after each release.
  - Updates are submitted through a pull request for review, using the corresponding release reference.

- **Chores**
  - Improved release automation to trigger documentation updates consistently after publishing a release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->