### PR TITLE
Generate README from the latest release tag

### DIFF
--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -29,8 +29,22 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Checkout the latest release tag
+        run: git checkout "$(git tag --list 'v*' --sort=-version:refname | head -n 1)"
+
       - name: Regenerate README
-        run: sbt generateInstallInstructions
+        run: |
+          sbt generateInstallInstructions
+          cp README.md "$RUNNER_TEMP/README.md"
+
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: master
+
+      - name: Restore the regenerated README
+        run: cp "$RUNNER_TEMP/README.md" README.md
 
       - name: Open README update pull request
         uses: peter-evans/create-pull-request@v8
@@ -40,14 +54,13 @@ jobs:
           branch: automation/regenerate-readme
           delete-branch: true
           commit-message: |
-            Regenerate README after release
+            Regenerate README
 
-            Update the generated installation instructions after publishing a release.
-          title: Regenerate README after release
+            Update the generated installation instructions.
+          title: Regenerate README
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            Regenerates the installation instructions in `README.md` after publishing
-            a release.
+            Regenerates the installation instructions in `README.md`.
 
             This pull request was created automatically by the
             [Regenerate README workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
## Summary

- keep the manual workflow input-free
- resolve and check out the latest `v*` release tag before running `sbt generateInstallInstructions`
- carry only the generated README back onto `master` before opening the PR
- use neutral generated-PR text for both automatic and manual runs

This prevents README updates from containing dynver snapshot coordinates derived from `master`.

## Validation

- `sbt githubWorkflowCheck`
- `git diff --check`
- generated from `v0.10.0` and verified the README contains `0.10.0`, not a snapshot version
